### PR TITLE
Abandon entrypoint.log, tracking by default way.

### DIFF
--- a/docker-library/apache-php-mysql/README.md
+++ b/docker-library/apache-php-mysql/README.md
@@ -53,7 +53,11 @@ You can access the builtin phpMyAdmin site with a URL like below if you're using
 4. Update the config file of your app with your created database information;
 
 ## Startup Log
-The startup log file (**entrypoint.log**) is placed under the folder /home/LogFiles.
+-After image deploy to Azure successfully.
+-Go to Azure portal, go to the blade for your web app and click Diagnostics logs.
+-On the Diagnostics logs blade, selecet "File System" of "Docker Container logging", set "Quota" and "Retention Period", Click Save.
+-Restart your web app.
+-The startup log is included by /home/LogFiles/RD????????????/docker.log.
 
 ## Change Log
 - **Version 0.2** 

--- a/docker-library/apache-php-mysql/README.md
+++ b/docker-library/apache-php-mysql/README.md
@@ -60,7 +60,6 @@ Startup log from entrypoint.sh is disabled by default. To enable startup log, yo
 4. Set *"Quota"* and *"Retention Period"*, and Click *"Save"*.
 4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
 
-
 On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
 #Replace RDXXXXXX with your actual folder name.
 ```
@@ -73,4 +72,4 @@ cat /home/LogFiles/RDXXXXXX/docker.log
   1. Supports uploading large files. See [php.ini](0.2/php.ini) here.
   2. New app setting item: DATABASE_TYPE, default value is "remote". You can set it to "local" to start the built-in MySQL database server. See [entrypoint.sh](0.2/entrypoint.sh) for more information.
   3. Dropped 3 app setting items: DATABASE_NAME, DATABASE_USER, and DATABASE_PASSWORD. Removal of these items has no impacts on your existing database or site contents.
-  4. Abandon entrypoint.log, replace with Azure internal docker container loggin file system.
+  4. Abandon entrypoint.log, replace with Azure internal docker container logging file system.

--- a/docker-library/apache-php-mysql/README.md
+++ b/docker-library/apache-php-mysql/README.md
@@ -61,8 +61,8 @@ Startup log from entrypoint.sh is disabled by default. To enable startup log, yo
 4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
 
 On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
-#Replace RDXXXXXX with your actual folder name.
 ```
+#Replace RDXXXXXX with your actual folder name.
 cat /home/LogFiles/RDXXXXXX/docker.log
 ```
 ---

--- a/docker-library/apache-php-mysql/README.md
+++ b/docker-library/apache-php-mysql/README.md
@@ -53,14 +53,15 @@ You can access the builtin phpMyAdmin site with a URL like below if you're using
 4. Update the config file of your app with your created database information;
 
 ## Startup Log
--After image deploy to Azure successfully.
--Go to Azure portal, go to the blade for your web app and click Diagnostics logs.
--On the Diagnostics logs blade, selecet "File System" of "Docker Container logging", set "Quota" and "Retention Period", Click Save.
--Restart your web app.
--The startup log is included by /home/LogFiles/RD????????????/docker.log.
+1. After deploy to Azure successfully.
+2. Go to Azure portal, go to the blade for your web app and click Diagnostics logs.
+3. On the Diagnostics logs blade, selecet *"File System"* of *"Docker Container logging"*, set *"Quota"* and *"Retention Period"*, Click Save.
+4. Restart your web app.
+5. The startup log is included by /home/LogFiles/RD????????????/docker.log.
 
 ## Change Log
 - **Version 0.2** 
   1. Supports uploading large files. See [php.ini](0.2/php.ini) here.
   2. New app setting item: DATABASE_TYPE, default value is "remote". You can set it to "local" to start the built-in MySQL database server. See [entrypoint.sh](0.2/entrypoint.sh) for more information.
   3. Dropped 3 app setting items: DATABASE_NAME, DATABASE_USER, and DATABASE_PASSWORD. Removal of these items has no impacts on your existing database or site contents.
+  4. Abandon entrypoint.log, replace with Azure internal docker container loggin file system.

--- a/docker-library/apache-php-mysql/README.md
+++ b/docker-library/apache-php-mysql/README.md
@@ -53,11 +53,20 @@ You can access the builtin phpMyAdmin site with a URL like below if you're using
 4. Update the config file of your app with your created database information;
 
 ## Startup Log
-1. After deploy to Azure successfully.
-2. Go to Azure portal, go to the blade for your web app and click Diagnostics logs.
-3. On the Diagnostics logs blade, selecet *"File System"* of *"Docker Container logging"*, set *"Quota"* and *"Retention Period"*, Click Save.
-4. Restart your web app.
-5. The startup log is included by /home/LogFiles/RD????????????/docker.log.
+Startup log from entrypoint.sh is disabled by default. To enable startup log, you can follow the steps below.
+1. Go to Azure portal, go to the blade of your web app.
+2. Click *"Diagnostics logs"*.
+3. On the *"Diagnostics logs"* blade, selecet *"File System"* under *"Docker Container logging"*.
+4. Set *"Quota"* and *"Retention Period"*, and Click *"Save"*.
+4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
+
+
+On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
+#Replace RDXXXXXX with your actual folder name.
+```
+cat /home/LogFiles/RDXXXXXX/docker.log
+```
+---
 
 ## Change Log
 - **Version 0.2** 

--- a/docker-library/apache-php-mysql/README.md
+++ b/docker-library/apache-php-mysql/README.md
@@ -58,7 +58,7 @@ Startup log from entrypoint.sh is disabled by default. To enable startup log, yo
 2. Click *"Diagnostics logs"*.
 3. On the *"Diagnostics logs"* blade, selecet *"File System"* under *"Docker Container logging"*.
 4. Set *"Quota"* and *"Retention Period"*, and Click *"Save"*.
-4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
+5. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
 
 On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
 ```
@@ -72,4 +72,4 @@ cat /home/LogFiles/RDXXXXXX/docker.log
   1. Supports uploading large files. See [php.ini](0.2/php.ini) here.
   2. New app setting item: DATABASE_TYPE, default value is "remote". You can set it to "local" to start the built-in MySQL database server. See [entrypoint.sh](0.2/entrypoint.sh) for more information.
   3. Dropped 3 app setting items: DATABASE_NAME, DATABASE_USER, and DATABASE_PASSWORD. Removal of these items has no impacts on your existing database or site contents.
-  4. Abandon entrypoint.log, replace with Azure internal docker container logging file system.
+  4. Abandon using entrypoint.log as startup log, replace it with Azure internal docker container logging file system.

--- a/docker-library/wordpress/0.3/entrypoint.sh
+++ b/docker-library/wordpress/0.3/entrypoint.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
-log(){
-	while read line ; do
-		echo "`date '+%D %T'` $line"
-	done
-}
-
 set -e
-logfile=/home/LogFiles/entrypoint.log
-test ! -f $logfile && mkdir -p /home/LogFiles && touch $logfile
-exec > >(log | tee -ai $logfile)
-exec 2>&1
 
 set_var_if_null(){
 	local varname="$1"

--- a/docker-library/wordpress/README.md
+++ b/docker-library/wordpress/README.md
@@ -100,7 +100,7 @@ Startup log from entrypoint.sh is disabled by default. To enable startup log, yo
 2. Click *"Diagnostics logs"*.
 3. On the *"Diagnostics logs"* blade, selecet *"File System"* under *"Docker Container logging"*.
 4. Set *"Quota"* and *"Retention Period"*, and Click *"Save"*.
-4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
+5. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
 
 On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
 ```
@@ -116,4 +116,4 @@ cat /home/LogFiles/RDXXXXXX/docker.log
 - **Version 0.3**
   1. Supports uploading large files. See [php.ini](0.3/php.ini) here;
   2. Supports Zlib. See [Dockerfile](0.3/Dockerfile) here.
-  3. Abandon entrypoint.log, replace with Azure internal docker container logging file system.
+  3. Abandon using entrypoint.log as startup log, replace it with Azure internal docker container logging file system.

--- a/docker-library/wordpress/README.md
+++ b/docker-library/wordpress/README.md
@@ -95,11 +95,20 @@ If you're using the builtin MariaDB, you can leverage the builtin Redis cache se
 The builtin Redis cache server uses port 6379.
 
 ## Startup Log
-1. After deploy to Azure successfully.
-2. Go to Azure portal, go to the blade for your web app and click Diagnostics logs.
-3. On the Diagnostics logs blade, selecet *"File System"* of *"Docker Container logging"*, set *"Quota"* and *"Retention Period"*, Click Save.
-4. Restart your web app.
-5. The startup log is included by /home/LogFiles/RD????????????/docker.log.
+Startup log from entrypoint.sh is disabled by default. To enable startup log, you can follow the steps below.
+1. Go to Azure portal, go to the blade of your web app.
+2. Click *"Diagnostics logs"*.
+3. On the *"Diagnostics logs"* blade, selecet *"File System"* under *"Docker Container logging"*.
+4. Set *"Quota"* and *"Retention Period"*, and Click *"Save"*.
+4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
+
+
+On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
+#Replace RDXXXXXX with your actual folder name.
+```
+cat /home/LogFiles/RDXXXXXX/docker.log
+```
+---
 
 ## Change Log
 - **Version 0.2**

--- a/docker-library/wordpress/README.md
+++ b/docker-library/wordpress/README.md
@@ -95,7 +95,11 @@ If you're using the builtin MariaDB, you can leverage the builtin Redis cache se
 The builtin Redis cache server uses port 6379.
 
 ## Startup Log
-The startup log file (**entrypoint.log**) is placed under the folder /home/LogFiles.
+1. After deploy to Azure successfully.
+2. Go to Azure portal, go to the blade for your web app and click Diagnostics logs.
+3. On the Diagnostics logs blade, selecet *"File System"* of *"Docker Container logging"*, set *"Quota"* and *"Retention Period"*, Click Save.
+4. Restart your web app.
+5. The startup log is included by /home/LogFiles/RD????????????/docker.log.
 
 ## Change Log
 - **Version 0.2**
@@ -104,3 +108,4 @@ The startup log file (**entrypoint.log**) is placed under the folder /home/LogFi
 - **Version 0.3**
   1. Supports uploading large files. See [php.ini](0.3/php.ini) here;
   2. Supports Zlib. See [Dockerfile](0.3/Dockerfile) here.
+  3. Abandon entrypoint.log, replace with Azure internal docker container loggin file system.

--- a/docker-library/wordpress/README.md
+++ b/docker-library/wordpress/README.md
@@ -102,7 +102,6 @@ Startup log from entrypoint.sh is disabled by default. To enable startup log, yo
 4. Set *"Quota"* and *"Retention Period"*, and Click *"Save"*.
 4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
 
-
 On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
 #Replace RDXXXXXX with your actual folder name.
 ```
@@ -117,4 +116,4 @@ cat /home/LogFiles/RDXXXXXX/docker.log
 - **Version 0.3**
   1. Supports uploading large files. See [php.ini](0.3/php.ini) here;
   2. Supports Zlib. See [Dockerfile](0.3/Dockerfile) here.
-  3. Abandon entrypoint.log, replace with Azure internal docker container loggin file system.
+  3. Abandon entrypoint.log, replace with Azure internal docker container logging file system.

--- a/docker-library/wordpress/README.md
+++ b/docker-library/wordpress/README.md
@@ -103,8 +103,8 @@ Startup log from entrypoint.sh is disabled by default. To enable startup log, yo
 4. Go to the "Overview" blade, Restart your web app by clicking *"Stop"* and then *"start"*.
 
 On Webssh run the command below to check if the startup logs from entrypoint.sh is enabled.
-#Replace RDXXXXXX with your actual folder name.
 ```
+#Replace RDXXXXXX with your actual folder name.
 cat /home/LogFiles/RDXXXXXX/docker.log
 ```
 ---


### PR DESCRIPTION
1) update README.md of APM.
2) update README.md and Entrypoint.sh of WordPress. Tested, it works.
3) Looks entrypoint.log has already been removed for Python, nothing changed.