### PR TITLE
Remove invalid char

### DIFF
--- a/docker-library/apache-php-mysql/0.3/httpd.conf
+++ b/docker-library/apache-php-mysql/0.3/httpd.conf
@@ -55,5 +55,5 @@ CustomLog "/var/log/httpd/access_log" common
     SetOutputFilter DEFLATE 
     SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzipdont-vary 
     SetEnvIfNoCase Request_URI .(?:exe|t?gz|zip|bz2|sit|rar)$ no-gzipdont-vary 
-    SetEnvIfNoCase Request_URI .(?:pdf|mov|avi|mp3|mp4|rm)$ no-gzipdont-vary 
+    SetEnvIfNoCase Request_URI .(?:pdf|mov|avi|mp3|mp4|rm)$ no-gzipdont-vary
 </IfModule>  


### PR DESCRIPTION
The image can be built successfully, but can't run. there is some invalid chars exist at last 2 lines of httpd.conf, remove them.

tested ,built successfully, docker run successfully.

